### PR TITLE
[GRDM-45886] prebuiltイメージ追加

### DIFF
--- a/AdminRDMAddonGuide/README.md
+++ b/AdminRDMAddonGuide/README.md
@@ -191,7 +191,7 @@ class AddonAppConfig(BaseAddonAppConfig):
 変更したファイルに関連するサービスを再起動します。
 
 ```
-$ docker-compose restart web api assets admin
+$ docker compose restart web api assets admin
 ```
 
 これでサービスへの反映は完了です。機関管理機能でスケルトン アドオンの設定を変更できることを確認するには、以下のような操作を実施します。
@@ -307,7 +307,7 @@ Admin Notesを表示するためのUIを追加します。
 makemigrations コマンドを実行して、Migrationsファイルを作成します。
 
 ```
-$ docker-compose run --rm web python3 manage.py makemigrations
+$ docker compose run --rm web python3 manage.py makemigrations
 ```
 
 上記の出力中に以下のような出力が現れれば成功です。
@@ -326,13 +326,13 @@ Migrations for 'osf':
 アドオンの機関管理機能におけるAdmin Notesに関するユニットテストは、以下のコマンドで実行できます。
 
 ```
-$ docker-compose run --rm web invoke test_module -m admin_tests/rdm_addons/api_v1/test_views.py::TestAdminNotesView
+$ docker compose run --rm web invoke test_module -m admin_tests/rdm_addons/api_v1/test_views.py::TestAdminNotesView
 ```
 
 スケルトン アドオンにおけるAdmin Notesに関するユニットテストは、以下のコマンドで実行できます。
 
 ```
-$ docker-compose run --rm web invoke test_module -m addons/myskelton/tests/test_view.py::TestAdminNotesViews
+$ docker compose run --rm web invoke test_module -m addons/myskelton/tests/test_view.py::TestAdminNotesViews
 ```
 
 # Admin Notesの動作確認
@@ -344,7 +344,7 @@ Admin Notesの動作を確認してみましょう。
 マイグレーションを実行し、Migrations定義をPostgreSQLサービスに反映します。
 
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 ```
 
 ## 国際化のコンパイル
@@ -352,7 +352,7 @@ $ docker-compose run --rm web python3 manage.py migrate
 テンプレートファイルの国際化設定を適用するために、国際化ファイルをコンパイルします。
 
 ```
-$ docker-compose run --rm web pybabel compile -D django -d ./admin/translations
+$ docker compose run --rm web pybabel compile -D django -d ./admin/translations
 ```
 
 ## サービスの再起動
@@ -360,7 +360,7 @@ $ docker-compose run --rm web pybabel compile -D django -d ./admin/translations
 変更したファイルに関するサービスを再起動します。
 
 ```
-$ docker-compose restart web api assets admin admin_assets
+$ docker compose restart web api assets admin admin_assets
 ```
 
 これでサービスへの反映は完了です。

--- a/Environment.md
+++ b/Environment.md
@@ -35,7 +35,7 @@ Dockerを用いることで、OS等の環境の差異をコンテナにより吸
   * WebサーバとAPIサーバに関する、Djangoの設定ファイル `local.py` を準備します。特に変更の必要がなければ、それぞれの `local-dist.py` をコピーして使用します。
   * RDM-osf.io, RDM-waterbutlerリポジトリを使用するよう、Docker Composeサービス定義ファイルを変更します。`docker-compose.yml` を直接変更するのではなく、 `docker-compose.override.yml` を変更することで、誤って開発環境固有の情報をリポジトリにコミットすることを防止することができます。
 3. アプリケーションの実行 - https://github.com/RCOSDP/RDM-osf.io/blob/develop/README-docker-compose.md#application-runtime
-  * このDocker Compose環境は、Dockerイメージをベースに各サービスを起動しますが、PythonモジュールやNodeモジュールはイメージとは異なるボリュームに保持します。(開発中に更新される可能性を想定しているものと思われます。) そのため、サービス実行前に `docker-compose up requirements mfr_requirements wb_requirements` を実施することで、必要なライブラリを各コンテナにインストールする必要があります。
+  * このDocker Compose環境は、Dockerイメージをベースに各サービスを起動しますが、PythonモジュールやNodeモジュールはイメージとは異なるボリュームに保持します。(開発中に更新される可能性を想定しているものと思われます。) そのため、サービス実行前に `docker compose up requirements mfr_requirements wb_requirements` を実施することで、必要なライブラリを各コンテナにインストールする必要があります。
 4. ツールの利用 - https://github.com/RCOSDP/RDM-osf.io/blob/develop/README-docker-compose.md#running-arbitrary-commands
   * DjangoのMigrationファイルの作成や、RDMが保持するModelの確認、テストの実行など、Docker Compose経由でコマンドを実行することで、容易にこれらのコマンドを実行できます。
 5. 環境のリセット - https://github.com/RCOSDP/RDM-osf.io/blob/develop/README-docker-compose.md#cleanup--docker-reset
@@ -88,11 +88,11 @@ services:
 
 ```
 # ライブラリのインストール - 初回/ライブラリ定義変更時だけ必要
-$ docker-compose up requirements mfr_requirements wb_requirements
+$ docker compose up requirements mfr_requirements wb_requirements
 # DBのマイグレーション - 初回/DB定義変更時だけ必要
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 
-$ docker-compose up -d assets admin_assets mfr wb wb_worker fakecas sharejs worker web api admin ember_osf_web
+$ docker compose up -d assets admin_assets mfr wb wb_worker fakecas sharejs worker web api admin ember_osf_web
 ```
 
 > https://github.com/RCOSDP/RDM-osf.io/blob/develop/README-docker-compose.md では preprints, registries の起動について紹介していますが、GRDMでは preprints, registries は提供しないため無視してください。
@@ -104,18 +104,18 @@ $ docker-compose up -d assets admin_assets mfr wb wb_worker fakecas sharejs work
 
 ```
 # ライブラリのインストール - 初回/ライブラリ定義変更時だけ必要
-$ docker-compose up requirements wb_requirements
+$ docker compose up requirements wb_requirements
 # DBのマイグレーション - 初回/DB定義変更時だけ必要
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 
-$ docker-compose up -d assets wb wb_worker fakecas worker web api ember_osf_web
+$ docker compose up -d assets wb wb_worker fakecas worker web api ember_osf_web
 ```
 
-でも十分でしょう。`docker-compose ps`で異常終了しているサービスがいないことを確認します。
-`docker-compose ps`の出力例は以下の通りです。`docker-compose up -d`で指定したサービスが`Up`であることを確認します。
+でも十分でしょう。`docker compose ps`で異常終了しているサービスがいないことを確認します。
+`docker compose ps`の出力例は以下の通りです。`docker compose up -d`で指定したサービスが`Up`であることを確認します。
 
 ```
-$ docker-compose ps
+$ docker compose ps
             Name                          Command               State                                              Ports                                           
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 rdm2-osfio_api_1               docker-entrypoint.sh invok ...   Up       0.0.0.0:8000->8000/tcp                                                                    
@@ -140,15 +140,15 @@ fakecasは手軽にRDMの動作確認を行えますが、OAuthの動作確認�
 
 ```
 # ライブラリのインストール - 初回/ライブラリ定義変更時だけ必要
-$ docker-compose up requirements wb_requirements
+$ docker compose up requirements wb_requirements
 # DBのマイグレーション - 初回/DB定義変更時だけ必要
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 
 # fakecasではなくcasをサービスに指定する
-$ docker-compose up -d assets wb wb_worker cas worker web api ember_osf_web
+$ docker compose up -d assets wb wb_worker cas worker web api ember_osf_web
 
 # OAuthのスコープを登録する
-$ docker-compose run --rm web python3 -m scripts.register_oauth_scopes
+$ docker compose run --rm web python3 -m scripts.register_oauth_scopes
 ```
 
 casはfakecasとは異なり、ログイン時に ユーザ作成手順(後述) において入力したパスワードが必要になります。他の操作方法はfakecasと同様です。
@@ -157,10 +157,10 @@ casはfakecasとは異なり、ログイン時に ユーザ作成手順(後述) 
 
 サービスが起動したことを確認したら、 `http://localhost:5000` にアクセスし動作を確認してみましょう。
 
-ログは `docker-compose logs` コマンドで確認できます。ember_osf_webコンテナは起動にある程度時間がかかりますが、この状態を確認するには、以下のコマンドを入力します。
+ログは `docker compose logs` コマンドで確認できます。ember_osf_webコンテナは起動にある程度時間がかかりますが、この状態を確認するには、以下のコマンドを入力します。
 
 ```
-$ docker-compose logs -f ember_osf_web
+$ docker compose logs -f ember_osf_web
 ...
 Build successful (xxxxxms) – Serving on http://0.0.0.0:4200/
 ```
@@ -171,7 +171,7 @@ Build successful (xxxxxms) – Serving on http://0.0.0.0:4200/
 
 1. `Sign Up`ボタンを押し、ユーザ登録画面を開く
 1. ユーザ登録画面に適当なユーザ名、Eメールアドレスとパスワードを入力する
-1. デバッグログにEメール到達確認用のURL(`http://localhost:5000/confirm/xxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/`)が出力されるので、 `docker-compose logs web` で確認する
+1. デバッグログにEメール到達確認用のURL(`http://localhost:5000/confirm/xxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/`)が出力されるので、 `docker compose logs web` で確認する
 
   > 本番環境の場合はここでEメールアドレス宛に到達確認用のURLを含むメールが届きますが、SMTPサーバを指定していないのでメールは送信されません。
 
@@ -192,9 +192,9 @@ Build successful (xxxxxms) – Serving on http://0.0.0.0:4200/
 
 ```
 # 初回だけ必要
-$ docker-compose up requirements
+$ docker compose up requirements
 
-$ docker-compose run --rm web invoke test
+$ docker compose run --rm web invoke test
 ```
 
 テストコードを限定する方法は https://github.com/RCOSDP/RDM-osf.io/blob/develop/README-docker-compose.md#application-tests に記載されています。
@@ -205,13 +205,13 @@ RDM-osf.ioはDjangoアプリケーションとして実装されています。�
 以下のコマンドを入力することで、Djangoの管理コマンド `makemigrations` を実行できます。
 
 ```
-$ docker-compose run --rm web python3 manage.py makemigrations
+$ docker compose run --rm web python3 manage.py makemigrations
 ```
 
 作成したMigrationsファイルは、以下のコマンドで `postgres`サービスに反映できます。
 
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 ```
 
 ## ユーザを機関に所属させる
@@ -222,7 +222,7 @@ $ docker-compose run --rm web python3 manage.py migrate
 まず、実行中のRDMのデータベースに機関の情報を登録します。これは初回だけ必要です。
 
 ```
-$ docker-compose run --rm web python3 -m scripts.populate_institutions -e test -a
+$ docker compose run --rm web python3 -m scripts.populate_institutions -e test -a
 ```
 
 上記のコマンドを実行すると、`Virginia Tech [Test]` などの機関名を持つ機関が登録されます。
@@ -230,7 +230,7 @@ $ docker-compose run --rm web python3 -m scripts.populate_institutions -e test -
 次に、shell機能を使って、ユーザに機関を紐付けます。以下のコマンドを実行します。
 
 ```
-$ docker-compose run --rm web invoke shell
+$ docker compose run --rm web invoke shell
 ```
 
 上記コマンドを実行すると、以下のようなプロンプトが現れますので、Pythonスクリプトで処理を指示します。下記のようにスクリプトを実行すると、指定したEmailアドレスを持つユーザのモデルを取得することができます。
@@ -271,7 +271,7 @@ New transaction opened.
 `is_staff`の編集には、shell機能を使います。
 
 ```
-$ docker-compose run --rm web invoke shell
+$ docker compose run --rm web invoke shell
 ```
 
 shellから以下のようにコマンドを実行することで、指定したユーザの `is_staff` プロパティを変更することができます。

--- a/Environment.md
+++ b/Environment.md
@@ -82,6 +82,8 @@ services:
       OAUTHLIB_INSECURE_TRANSPORT: '1'
   worker:
     image: niicloudoperation/rdm-osf.io:latest
+  ember_osf_web:
+    image: niicloudoperation/rdm-ember-osf-web:latest
   cas:
     image: niicloudoperation/rdm-cas-overlay:latest
   mfr:

--- a/Environment.md
+++ b/Environment.md
@@ -49,25 +49,32 @@ GakuNin RDMの最新Docker Imageをベースに開発を行うには、これら
 (`docker-compose.yml` と同じディレクトリに作成してください。)
 
 ```
+# Apple Silicon搭載Macの場合、platform指定のコメントアウト部分を外してARM版イメージを使用してください。
 services:
   fakecas:
     image: niicloudoperation/rdm-fakecas:latest
-  # Apple Silicon搭載Macの場合、以下をコメントアウトしてARM版Elasticsearchイメージを使用してください。
+    # platform: linux/arm64
+  # Apple Silicon搭載Macの場合、以下のコメントアウト部分を外してARM版Elasticsearchイメージを使用してください。
   # elasticsearch:
   #   image: quay.io/centerforopenscience/elasticsearch:es6-arm-6.3.1
   #   platform: linux/arm64
   admin:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
     environment:
       AWS_EC2_METADATA_DISABLED: "true"
   admin_assets:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
   api:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
   assets:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
   requirements:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
     command:
       - /bin/bash
       - -c
@@ -78,34 +85,53 @@ services:
         cp -Rf -p /usr/lib/python3.6 /
   web:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
     environment:
       OAUTHLIB_INSECURE_TRANSPORT: '1'
+    # macOS 15.1.1以降の場合、5000ポートが使用されている場合があります。その場合は以下のコメントアウトをはずしてポートを変更してください。
+    # また、 `.docker-compose.env`, `.docker-compose.mfr.env`, `.docker-compose.wb.env` のポート指定 `:5000` にも同様の
+    # 変更を行ってください。
+    # ports: !override
+    #   - 5001:5000
   worker:
     image: niicloudoperation/rdm-osf.io:latest
+    # platform: linux/arm64
   ember_osf_web:
     image: niicloudoperation/rdm-ember-osf-web:latest
+    # platform: linux/amd64
   cas:
     image: niicloudoperation/rdm-cas-overlay:latest
+    # platform: linux/amd64
   mfr:
     image: niicloudoperation/rdm-modular-file-renderer:latest
+    # platform: linux/amd64
+    # ローカルのRDM-modular-file-rendererを試したい場合
     # volumes:
     #   - ../RDM-modular-file-renderer:/code
   mfr_requirements:
     image: niicloudoperation/rdm-modular-file-renderer:latest
+    # platform: linux/amd64
+    # ローカルのRDM-modular-file-rendererを試したい場合
     # volumes:
     #   - ../RDM-modular-file-renderer:/code
   wb:
     image: niicloudoperation/rdm-waterbutler:latest
+    # platform: linux/arm64
+    # ローカルのRDM-waterbutlerを試したい場合
     # volumes:
     #   - ../RDM-waterbutler:/code
   wb_worker:
     image: niicloudoperation/rdm-waterbutler:latest
+    # platform: linux/arm64
+    # ローカルのRDM-waterbutlerを試したい場合
     # volumes:
     #   - ../RDM-waterbutler:/code
   wb_requirements:
     image: niicloudoperation/rdm-waterbutler:latest
+    # platform: linux/arm64
+    # ローカルのRDM-waterbutlerを試したい場合
     # volumes:
-    #   - ../RDM2-waterbutler:/code
+    #   - ../RDM-waterbutler:/code
 ```
 
 # 開発環境でRDMを起動する

--- a/ScreenExpansion/README.md
+++ b/ScreenExpansion/README.md
@@ -369,7 +369,7 @@ msgstr "パラメーター1"
 `makemigrations` コマンドを実行して、Migrationsファイルを作成します。
 
 ```
-$ docker-compose run --rm web python3 manage.py makemigrations
+$ docker compose run --rm web python3 manage.py makemigrations
 ```
 
 上記の出力中に以下のような出力が現れれば成功です。
@@ -495,7 +495,7 @@ Migrations for 'addons_myscreen':
 以下のコマンドで、OSF.ioに追加したMy Screenアドオンのユニットテストを実行できます。
 
 ```
-$ docker-compose run --rm web invoke test_module -m addons/myscreen/tests/
+$ docker compose run --rm web invoke test_module -m addons/myscreen/tests/
 ```
 
 ## ember-osf-webへの実装
@@ -636,28 +636,28 @@ services:
 コントローラの単体テスト:
 
 ```
-$ docker-compose run --rm ember_osf_web yarn test --module 'Unit | Controller | guid-node/myscreen'
+$ docker compose run --rm ember_osf_web yarn test --module 'Unit | Controller | guid-node/myscreen'
 ```
 
 ナビゲーションバーの結合テスト:
 
 ```
-$ docker-compose run --rm ember_osf_web yarn test --module 'Integration | Component | node-navbar'
+$ docker compose run --rm ember_osf_web yarn test --module 'Integration | Component | node-navbar'
 ```
 
 画面タブの受け入れテスト:
 
 ```
-$ docker-compose run --rm ember_osf_web yarn test --module 'Acceptance | guid-node/myscreen'
+$ docker compose run --rm ember_osf_web yarn test --module 'Acceptance | guid-node/myscreen'
 ```
 
 ファイルを指定してlintを実行するのは、以下のコマンドを実行します。
 
 ```
-$ docker-compose run --rm ember_osf_web node_modules/.bin/eslint --ext js,ts --max-warnings=0 'app/guid-node/myscreen' 'app/**/myscreen-config.ts' 'app/router.ts' 'lib/osf-components/addon/components/node-navbar/component.ts' 'tests/integration/components/node-navbar/component-test.ts' 'mirage/config.ts'
-$ docker-compose run --rm ember_osf_web node_modules/.bin/tslint -p . 'app/guid-node/myscreen/**/*.ts' 'app/**/myscreen-config.ts' 'app/router.ts' 'lib/osf-components/addon/components/node-navbar/component.ts' 'tests/integration/components/node-navbar/component-test.ts' 'mirage/config.ts'
-$ docker-compose run --rm ember_osf_web node_modules/.bin/stylelint 'app/guid-node/myscreen/**/*.scss'
-$ docker-compose run --rm ember_osf_web node_modules/.bin/ember-template-lint 'app/guid-node/myscreen/**/*.hbs' 'lib/osf-components/addon/components/node-navbar/template.hbs'
+$ docker compose run --rm ember_osf_web node_modules/.bin/eslint --ext js,ts --max-warnings=0 'app/guid-node/myscreen' 'app/**/myscreen-config.ts' 'app/router.ts' 'lib/osf-components/addon/components/node-navbar/component.ts' 'tests/integration/components/node-navbar/component-test.ts' 'mirage/config.ts'
+$ docker compose run --rm ember_osf_web node_modules/.bin/tslint -p . 'app/guid-node/myscreen/**/*.ts' 'app/**/myscreen-config.ts' 'app/router.ts' 'lib/osf-components/addon/components/node-navbar/component.ts' 'tests/integration/components/node-navbar/component-test.ts' 'mirage/config.ts'
+$ docker compose run --rm ember_osf_web node_modules/.bin/stylelint 'app/guid-node/myscreen/**/*.scss'
+$ docker compose run --rm ember_osf_web node_modules/.bin/ember-template-lint 'app/guid-node/myscreen/**/*.hbs' 'lib/osf-components/addon/components/node-navbar/template.hbs'
 ```
 
 
@@ -670,7 +670,7 @@ My Screenアドオンの動作確認をしてみましょう。
 マイグレーションを実行し、Migrations定義をPostgreSQLサービスに反映します。
 
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 ```
 
 ## 国際化のコンパイル
@@ -678,7 +678,7 @@ $ docker-compose run --rm web python3 manage.py migrate
 `.mako` ファイルの国際化設定を適用するために、国際化ファイルをコンパイルします。
 
 ```
-$ docker-compose run --rm web pybabel compile -d ./website/translations
+$ docker compose run --rm web pybabel compile -d ./website/translations
 ```
 
 > `.js` ファイルの国際化設定は、 `assets` サービスの再起動時に適用されます。
@@ -688,7 +688,7 @@ $ docker-compose run --rm web pybabel compile -d ./website/translations
 変更したファイルに関連するサービスを再起動します。
 
 ```
-$ docker-compose restart assets web api ember_osf_web
+$ docker compose restart assets web api ember_osf_web
 ```
 
 これでサービスへの反映は完了です。

--- a/SetupOsfOnEC2.md
+++ b/SetupOsfOnEC2.md
@@ -225,14 +225,14 @@ OSF_COOKIE_DOMAIN = 'ec2.compute-1.amazonaws.com'
 
 Ensure you have the required services running:
 ```bash
-sudo docker-compose up requirements wb_requirements mfr_requirements
+sudo docker compose up requirements wb_requirements mfr_requirements
 ```
 
 ### 7. Start Core Component Services (Detached)
 
 Spin up denpent services:
 ```bash
-sudo docker-compose up -d elasticsearch elasticsearch6 postgres mongo rabbitmq
+sudo docker compose up -d elasticsearch elasticsearch6 postgres mongo rabbitmq
 ```
 
 ### 8. Assets Setup
@@ -243,7 +243,7 @@ sudo rm -Rf ./node_modules
 sudo rm -Rf ./website/static/vendor/bower_components
 sudo rm -Rf ./admin/node_modules
 sudo rm -Rf ./admin/static/vendor/bower_components
-sudo docker-compose up -d assets admin_assets
+sudo docker compose up -d assets admin_assets
 ```
 
 ### 9. More Services
@@ -256,14 +256,14 @@ pytest-xdist==1.34.0
 
 Start additional services:
 ```bash
-sudo docker-compose up -d unoconv mfr wb fakecas sharejs
+sudo docker compose up -d unoconv mfr wb fakecas sharejs
 ```
 
 ### 10. Database Migration
 When starting with an empty database you will need to run migrations and populate preprint providers. 
 Perform database migrations:
 ```bash
-sudo docker-compose run --rm web python3 manage.py migrate
+sudo docker compose run --rm web python3 manage.py migrate
 ```
 See the [Running arbitrary commands](RDM-osf.io/README-docker-compose.md#running-arbitrary-commands) section below for instructions.
 
@@ -271,7 +271,7 @@ See the [Running arbitrary commands](RDM-osf.io/README-docker-compose.md#running
 
 Finally start the OSF Web, API Server, and Preprints (Detached):
 ```bash
-sudo docker-compose up -d wb_worker worker web api admin preprints ember_osf_web registries reviews
+sudo docker compose up -d wb_worker worker web api admin preprints ember_osf_web registries reviews
 ```
 
 We can see containers and images list.
@@ -326,7 +326,7 @@ Description=Let's Encrypt certificate renewal
 
 [Service]
 Type=oneshot
-ExecStart=certbot renew --dns-route53 --quiet --agree-tos --deploy-hook "cd /home/ubuntu/RDM-osf.io && sudo docker-compose restart web admin wb fakecas ember_osf_web  preprints registries reviews"
+ExecStart=certbot renew --dns-route53 --quiet --agree-tos --deploy-hook "cd /home/ubuntu/RDM-osf.io && sudo docker compose restart web admin wb fakecas ember_osf_web  preprints registries reviews"
 ```
 
 Then create /etc/systemd/system/certbot.timer:
@@ -382,7 +382,7 @@ Create a user via register link: https://EC2-url:5000/register/
 Method 2:
 Create a user directly through the RDM shell.
 ```bash
-docker-compose run --rm web invoke shell
+docker compose run --rm web invoke shell
 ```
 Create an OSF User with python code:
 ```python

--- a/Skelton/README.md
+++ b/Skelton/README.md
@@ -262,7 +262,7 @@ Migrationsファイルは、Modelの内容をRDBのテーブルに対応づけ�
 Modelで定義したプロパティがRDBに保存されるよう、`makemigrations`コマンドを実行します。このコマンドを実行すると、 `addons/myskelton/migrations` にPythonファイルが作成されます。
 
 ```
-$ docker-compose run --rm web python3 manage.py makemigrations
+$ docker compose run --rm web python3 manage.py makemigrations
 ```
 
 上記の出力中に以下の出力が現れれば成功です。現れない場合、RDMがアドオンを認識していない可能性があります。特に`addons.json`, `api/base/settings/defaults.py`の設定が漏れていないかどうかを確認してください。
@@ -281,14 +281,14 @@ Migrations for 'addons_myskelton':
 
 ```
 # framework/addons/data/addons.jsonに定義されたメッセージをJavaScriptファイルへと変換する
-$ docker-compose run --rm web python3 -m scripts.generate_addons_translations
+$ docker compose run --rm web python3 -m scripts.generate_addons_translations
 
 # メッセージ定義テンプレートファイル website/translations/js_messages.pot を更新する
-$ docker-compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
+$ docker compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
 
 # メッセージ定義ファイル website/translations/ja/LC_MESSAGES/js_messages.po を更新する
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
 ```
 
 上記を実行すると、`website/translations/ja/LC_MESSAGES/js_messages.po`にある英語メッセージと日本語メッセージの対応づけが更新されます。
@@ -318,7 +318,7 @@ msgstr ""
 これでアドオンのコードの作成は完了です。以下のコマンドで追加した `addons/myskelton` のユニットテストを実行してみましょう。
 
 ```
-$ docker-compose run --rm web invoke test_module -m addons/myskelton/tests/
+$ docker compose run --rm web invoke test_module -m addons/myskelton/tests/
 ```
 
 # スケルトン アドオンの動作確認
@@ -327,13 +327,13 @@ $ docker-compose run --rm web invoke test_module -m addons/myskelton/tests/
 アドオンには新規に定義されたModelが含まれていますので、Migrations定義をサービス中のPostgreSQLサービスに反映しましょう。
 
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 ```
 
 また、新規にJavaScriptファイルを追加したので、新たなファイルがロード対象となるように、`RDM-osf.io`をイメージとしたサービスの再起動を実施します。
 
 ```
-$ docker-compose restart assets web api
+$ docker compose restart assets web api
 ```
 
 これでサービスへの反映は完了です。スケルトン アドオンを試すには、以下のような操作を実施します。

--- a/StorageAddon/README.md
+++ b/StorageAddon/README.md
@@ -334,14 +334,14 @@ self.owner.add_log(
 
 ```
 # メッセージ定義JSONなどをJavaScriptファイルへと変換する
-$ docker-compose run --rm web invoke assets
+$ docker compose run --rm web invoke assets
 
 # メッセージ定義テンプレートファイル website/translations/js_messages.pot を更新する
-$ docker-compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
+$ docker compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
 
 # メッセージ定義ファイル website/translations/ja/LC_MESSAGES/js_messages.po を更新する
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
 ```
 
 すると、`website/translations/ja/LC_MESSAGES/js_messages.po`ファイルに、以下のような空の項目が追加されます。
@@ -363,7 +363,7 @@ msgstr "${user}が My MinIOバケット(${bucket})を接続しました"
 `js_messages.po` を変更したら、`assets`サービスを再起動してください。最新の`js_messages.po`ファイルがメッセージの表示に使用されるようになります。
 
 ```
-$ docker-compose restart assets
+$ docker compose restart assets
 ```
 
 ## タイムスタンプの処理
@@ -506,7 +506,7 @@ ADDONS_OAUTH.append('myminio')
 `makemigrations` コマンドを実行して、Migrationsファイルを作成します。
 
 ```
-$ docker-compose run --rm web python3 manage.py makemigrations
+$ docker compose run --rm web python3 manage.py makemigrations
 ```
 
 上記の出力中に以下のような出力が現れれば成功です。ストレージアドオンの場合、 `osf/migrations` と `addons/myminio/migrations` の2つのディレクトリ内にPythonファイルが作成されます。
@@ -535,14 +535,14 @@ Migrations for 'addons_myminio':
 
 ```
 # メッセージ定義JSONなどをJavaScriptファイルへと変換する。各サービスが停止している状態で実施する。
-$ docker-compose run --rm web invoke assets
+$ docker compose run --rm web invoke assets
 
 # メッセージ定義テンプレートファイル website/translations/js_messages.pot を更新する
-$ docker-compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
+$ docker compose run --rm web pybabel extract -F ./website/settings/babel_js.cfg -o ./website/translations/js_messages.pot .
 
 # メッセージ定義ファイル website/translations/ja/LC_MESSAGES/js_messages.po を更新する
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
-$ docker-compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/en/LC_MESSAGES/js_messages.po -l en
+$ docker compose run --rm web pybabel update -i ./website/translations/js_messages.pot -o ./website/translations/ja/LC_MESSAGES/js_messages.po -l ja
 ```
 
 変更例のサンプル [js_messages.po](osf.io/config/website/translations/ja/LC_MESSAGES/js_messages.po) を参考に日本語メッセージを追加してください。
@@ -566,7 +566,7 @@ msgstr "${user}が${node}のMy MinIOバケット(${bucket})の選択を解除し
 以下のコマンドで、OSF.ioに追加したMy MinIOアドオンのユニットテストを実行できます。
 
 ```
-$ docker-compose run --rm web invoke test_module -m addons/myminio/tests/
+$ docker compose run --rm web invoke test_module -m addons/myminio/tests/
 ```
 
 ## WaterButlerへの実装
@@ -622,7 +622,7 @@ services:
 以下のコマンドで、WaterButlerに追加したMy MinIOアドオン Providerのユニットテストを実行できます。
 
 ```
-$ docker-compose run --rm wb invoke test --provider myminio
+$ docker compose run --rm wb invoke test --provider myminio
 ```
 
 
@@ -661,7 +661,7 @@ RDMとMinIOサービスを同じ環境で実行している場合は、ループ
 マイグレーションを実行し、Migrations定義をPostgreSQLサービスに反映します。
 
 ```
-$ docker-compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py migrate
 ```
 
 ## サービスの再起動
@@ -669,13 +669,13 @@ $ docker-compose run --rm web python3 manage.py migrate
 WaterButlerに追加したProviderを有効にするために、 `wb_requirements` を起動します。
 
 ```
-$ docker-compose up wb_requirements
+$ docker compose up wb_requirements
 ```
 
 変更したファイルに関連するサービスを再起動します。
 
 ```
-$ docker-compose restart assets web api wb
+$ docker compose restart assets web api wb
 ```
 
 これでサービスへの反映は完了です。


### PR DESCRIPTION
簡単に開発環境を起動可能にするため、ビルドずみイメージを https://hub.docker.com/u/niicloudoperation にPushし、これを参照する `docker-compose.override.yml` を追加しました。
また、docker-composeコマンドは最新Docker Desktopでは docker compose とするのが良いように思いますのでこれも修正しています。